### PR TITLE
k8s: update Deployment apiVersion

### DIFF
--- a/nodevoto.yml
+++ b/nodevoto.yml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: nodevoto
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -50,7 +50,7 @@ spec:
     port: 8080
     targetPort: 8080
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -96,7 +96,7 @@ spec:
     port: 8080
     targetPort: 8080
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -148,7 +148,7 @@ spec:
     port: 80
     targetPort: 80
 ---
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
Deploying this app on the latest version of `minikube` gives the following error:

```log
$ cat nodevoto.yml | minikube kubectl -- apply -f -
namespace/nodevoto created
service/gif-svc created
service/voting-svc created
service/web-svc created
unable to recognize "STDIN": no matches for kind "Deployment" in version "apps/v1beta1"
unable to recognize "STDIN": no matches for kind "Deployment" in version "apps/v1beta1"
unable to recognize "STDIN": no matches for kind "Deployment" in version "apps/v1beta1"
unable to recognize "STDIN": no matches for kind "Deployment" in version "apps/v1beta1"
```

This PR updates the `apiVersion` of `Deployment` so that it works.

---

I found your repo from [this k8s blog post](https://kubernetes.io/blog/2018/11/07/grpc-load-balancing-on-kubernetes-without-tears/).